### PR TITLE
Add default emergency subscription and credentials

### DIFF
--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -6,6 +6,9 @@
     <!-- Main app constants -->
     <string name="app_name" translatable="false">QuakeAlert</string>
     <string name="app_base_url" translatable="false">https://quakealert.bananapixel.my.id/ntfy</string> <!-- If changed, you must also change google-services.json! -->
+    <string name="default_subscription_topic" translatable="false">peringatan_gempa_darurat_xyz</string>
+    <string name="default_user_username" translatable="false">vito100</string>
+    <string name="default_user_password" translatable="false">Archerc80new</string>
 
     <!-- Main activity -->
     <string name="main_menu_report_bug_url" translatable="false">https://github.com/binwiederhier/ntfy/issues</string>


### PR DESCRIPTION
## Summary
- automatically add the `peringatan_gempa_darurat_xyz` topic on startup so the emergency channel is pre-subscribed
- provision the default ntfy server credentials (username `vito100`, password `Archerc80new`) in app resources and persist them
- reuse the new constants when seeding the subscription and when fetching any cached notifications

## Testing
- ./gradlew lint *(fails: Android SDK not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1b5f47a4832db2e37c42f226d488