### PR TITLE
Add quake reports drawer with data fetching

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReport.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReport.kt
@@ -1,0 +1,185 @@
+package io.heckel.ntfy.ui.reports
+
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.Locale
+
+/**
+ * Represents a single earthquake report fetched from the quakealert backend.
+ */
+data class QuakeReport(
+    val headline: String,
+    val subline: String?,
+    val details: List<Pair<String, String>>
+)
+
+/**
+ * Parses the JSON payload returned by https://quakealert.bananapixel.my.id/laporan into
+ * a list of [QuakeReport]s. The server payload is not strictly defined, so the parser is
+ * intentionally resilient: It supports objects, arrays and a range of common field names
+ * that the endpoint is known to use. Unknown structures are rendered as readable text so
+ * the app can still present something meaningful to the user.
+ */
+object QuakeReportParser {
+    private val ROOT_ARRAY_KEYS = listOf("laporan", "reports", "data", "items", "result", "results")
+    private val HEADLINE_KEYS = listOf("wilayah", "lokasi", "location", "area", "region", "kejadian", "keterangan", "title", "judul", "info")
+    private val DATE_KEYS = listOf("tanggal", "date", "tgl")
+    private val TIME_KEYS = listOf("jam", "time", "waktu")
+
+    fun parse(rawBody: String): List<QuakeReport> {
+        val body = rawBody.trim()
+        if (body.isEmpty()) {
+            return emptyList()
+        }
+
+        return try {
+            when {
+                body.startsWith("[") -> parseArray(JSONArray(body))
+                body.startsWith("{") -> parseRootObject(JSONObject(body))
+                else -> listOf(QuakeReport(body, null, emptyList()))
+            }
+        } catch (e: JSONException) {
+            listOf(QuakeReport(body, null, emptyList()))
+        }
+    }
+
+    private fun parseRootObject(root: JSONObject): List<QuakeReport> {
+        ROOT_ARRAY_KEYS.forEach { key ->
+            if (root.has(key)) {
+                return parseArrayValue(root.get(key))
+            }
+        }
+        return parseArrayValue(root)
+    }
+
+    private fun parseArrayValue(value: Any?): List<QuakeReport> {
+        return when (value) {
+            is JSONArray -> parseArray(value)
+            is JSONObject -> listOf(parseObject(value))
+            null -> emptyList()
+            else -> listOf(QuakeReport(value.toString(), null, emptyList()))
+        }
+    }
+
+    private fun parseArray(array: JSONArray): List<QuakeReport> {
+        val list = mutableListOf<QuakeReport>()
+        for (i in 0 until array.length()) {
+            when (val item = array.opt(i)) {
+                is JSONObject -> list.add(parseObject(item))
+                is JSONArray -> list.addAll(parseArray(item))
+                null -> Unit
+                else -> list.add(QuakeReport(item.toString(), null, emptyList()))
+            }
+        }
+        return list
+    }
+
+    private fun parseObject(obj: JSONObject): QuakeReport {
+        val fields = mutableListOf<ReportField>()
+        val iterator = obj.keys()
+        while (iterator.hasNext()) {
+            val key = iterator.next()
+            val value = obj.opt(key)
+            val formattedValue = formatValue(value)
+            if (formattedValue.isNotBlank()) {
+                fields.add(ReportField(key, formatKey(key), formattedValue))
+            }
+        }
+
+        if (fields.isEmpty()) {
+            return QuakeReport("Laporan", null, emptyList())
+        }
+
+        val headlineField = fields.firstOrNull { field ->
+            HEADLINE_KEYS.any { candidate -> field.rawKey.equals(candidate, ignoreCase = true) }
+        }
+        val dateField = fields.firstOrNull { field ->
+            DATE_KEYS.any { candidate -> field.rawKey.equals(candidate, ignoreCase = true) }
+        }
+        val timeField = fields.firstOrNull { field ->
+            TIME_KEYS.any { candidate -> field.rawKey.equals(candidate, ignoreCase = true) }
+        }
+
+        val sublineParts = mutableListOf<String>()
+        dateField?.value?.takeIf { it.isNotBlank() }?.let(sublineParts::add)
+        timeField?.value?.takeIf { it.isNotBlank() }?.let(sublineParts::add)
+        val subline = if (sublineParts.isEmpty()) null else sublineParts.joinToString(separator = " • ")
+
+        val headline = headlineField?.value?.takeIf { it.isNotBlank() }
+            ?: fields.firstOrNull { it !== dateField && it !== timeField }?.value
+            ?: dateField?.value
+            ?: "Laporan"
+
+        val remainingFields = fields.filterNot { field ->
+            headlineField != null && field.rawKey.equals(headlineField.rawKey, ignoreCase = true)
+        }
+        val details = mutableListOf<Pair<String, String>>()
+        if (headlineField != null && headlineField.displayLabel.isNotBlank() && remainingFields.isNotEmpty()) {
+            details.add(headlineField.displayLabel to headlineField.value)
+        }
+        details.addAll(remainingFields.map { field -> field.displayLabel to field.value })
+
+        return QuakeReport(headline, subline, details)
+    }
+
+    private fun formatValue(value: Any?): String {
+        return when (value) {
+            null -> ""
+            is JSONArray -> buildString {
+                for (i in 0 until value.length()) {
+                    val item = value.opt(i)
+                    val text = formatValue(item)
+                    if (text.isNotBlank()) {
+                        if (isNotEmpty()) append('\n')
+                        append("• ")
+                        append(text)
+                    }
+                }
+            }
+            is JSONObject -> formatNestedObject(value)
+            else -> value.toString().trim()
+        }
+    }
+
+    private fun formatNestedObject(obj: JSONObject): String {
+        val builder = StringBuilder()
+        val iterator = obj.keys()
+        while (iterator.hasNext()) {
+            val key = iterator.next()
+            val value = formatValue(obj.opt(key))
+            if (value.isNotBlank()) {
+                if (builder.isNotEmpty()) {
+                    builder.append('\n')
+                }
+                builder.append(formatKey(key))
+                builder.append(':')
+                builder.append(' ')
+                builder.append(value)
+            }
+        }
+        return builder.toString()
+    }
+
+    private fun formatKey(key: String): String {
+        return key.replace('_', ' ')
+            .split(' ', '-', '.', ':')
+            .flatMap { segment ->
+                segment.replace(Regex("(?<=[A-Za-z])(?=[A-Z0-9])"), " ")
+                    .split(' ')
+            }
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { part ->
+                part.lowercase(Locale.getDefault()).replaceFirstChar { ch ->
+                    if (ch.isLowerCase()) ch.titlecase(Locale.getDefault()) else ch.toString()
+                }
+            }
+            .ifEmpty { key }
+    }
+
+    private data class ReportField(
+        val rawKey: String,
+        val displayLabel: String,
+        val value: String
+    )
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
@@ -1,0 +1,63 @@
+package io.heckel.ntfy.ui.reports
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import io.heckel.ntfy.R
+
+class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHolder>(DiffCallback) {
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_quake_report, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = getItem(position)
+        holder.title.text = item.headline
+        holder.subtitle.isVisible = !item.subline.isNullOrBlank()
+        holder.subtitle.text = item.subline
+        if (item.details.isEmpty()) {
+            holder.details.isVisible = false
+            holder.details.text = ""
+        } else {
+            holder.details.isVisible = true
+            holder.details.text = item.details.joinToString(separator = "\n") { (label, value) ->
+                if (label.isBlank()) {
+                    value
+                } else {
+                    "• $label: $value"
+                }
+            }
+        }
+    }
+
+    override fun getItemId(position: Int): Long {
+        return getItem(position).hashCode().toLong()
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val title: TextView = view.findViewById(R.id.report_title)
+        val subtitle: TextView = view.findViewById(R.id.report_subtitle)
+        val details: TextView = view.findViewById(R.id.report_details)
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<QuakeReport>() {
+        override fun areItemsTheSame(oldItem: QuakeReport, newItem: QuakeReport): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: QuakeReport, newItem: QuakeReport): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsService.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsService.kt
@@ -1,0 +1,34 @@
+package io.heckel.ntfy.ui.reports
+
+import io.heckel.ntfy.msg.ApiService
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+object QuakeReportsService {
+    private const val REPORTS_URL = "https://quakealert.bananapixel.my.id/laporan"
+
+    private val client = OkHttpClient.Builder()
+        .callTimeout(30, TimeUnit.SECONDS)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    @Throws(IOException::class)
+    fun fetchReports(): List<QuakeReport> {
+        val request = Request.Builder()
+            .url(REPORTS_URL)
+            .addHeader("User-Agent", ApiService.USER_AGENT)
+            .addHeader("Accept", "application/json")
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Unexpected response ${'$'}{response.code}")
+            }
+            val body = response.body?.string().orEmpty()
+            return QuakeReportParser.parse(body)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-                                                   android:layout_height="match_parent">
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
@@ -287,4 +294,82 @@
             style="@style/FloatingActionButton"
     />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/reports_drawer"
+        android:layout_width="320dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:background="?attr/colorSurface"
+        android:gravity="top"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="24dp">
+
+        <TextView
+            android:id="@+id/reports_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:text="@string/reports_drawer_title"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+            android:textColor="?attr/colorOnSurface" />
+
+        <ProgressBar
+            android:id="@+id/reports_progress"
+            style="@style/Widget.AppCompat.ProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:indeterminate="true"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/reports_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center"
+            android:padding="12dp"
+            android:text="@string/reports_error_text"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="?attr/colorError"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/reports_empty"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center"
+            android:padding="12dp"
+            android:text="@string/reports_empty_text"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="?attr/colorOnSurface"
+            android:visibility="gone" />
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/reports_refresh"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:visibility="gone">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/reports_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:scrollbars="vertical"
+                android:paddingTop="4dp"
+                android:paddingBottom="16dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </LinearLayout>
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/item_quake_report.xml
+++ b/app/src/main/res/layout/item_quake_report.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginBottom="12dp"
+    app:cardUseCompatPadding="true"
+    app:strokeWidth="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/report_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold"
+            android:maxLines="2"
+            android:ellipsize="end" />
+
+        <TextView
+            android:id="@+id/report_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="?attr/colorOnSurface"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/report_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="?attr/colorOnSurface"
+            android:lineSpacingExtra="4dp" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_main_action_bar.xml
+++ b/app/src/main/res/menu/menu_main_action_bar.xml
@@ -6,6 +6,8 @@
     <item android:id="@+id/main_menu_notifications_disabled_forever" android:title="@string/detail_menu_notifications_disabled_forever"
           app:showAsAction="ifRoom" android:icon="@drawable/ic_notifications_off_white_outline_24dp"/>
     <item android:id="@+id/main_menu_settings" android:title="@string/main_menu_settings_title"/>
+    <item android:id="@+id/main_menu_reports" android:title="@string/main_menu_reports_title"
+        android:icon="@drawable/ic_bolt_white_24dp" app:showAsAction="ifRoom"/>
     <item android:id="@+id/main_menu_docs" android:title="@string/main_menu_docs_title"/>
     <item android:id="@+id/main_menu_rate" android:title="@string/main_menu_rate_title"/>
     <item android:id="@+id/main_menu_donate" android:title="@string/main_menu_donate_title"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="main_menu_docs_title">Read the docs</string>
     <string name="main_menu_rate_title">Rate the app ⭐</string>
     <string name="main_menu_donate_title">Donate 💸</string>
+    <string name="main_menu_reports_title">Quake reports</string>
 
     <!-- Main activity: Action mode -->
     <string name="main_action_mode_menu_unsubscribe">Unsubscribe</string>
@@ -87,6 +88,13 @@
     <string name="main_banner_websocket_reconnect_button_remind_later">Ask later</string>
     <string name="main_banner_websocket_reconnect_button_dismiss">Dismiss</string>
     <string name="main_banner_websocket_reconnect_button_enable_now">Grant now</string>
+
+    <!-- Main activity: Quake reports drawer -->
+    <string name="reports_drawer_title">Quake reports</string>
+    <string name="reports_empty_text">No quake reports available. Pull to refresh.</string>
+    <string name="reports_error_text">Unable to load quake reports. Pull to refresh or tap to retry.</string>
+    <string name="reports_error_with_reason">Unable to load quake reports. Pull to refresh or tap to retry.
+%1$s</string>
 
     <!-- Add dialog -->
     <string name="add_dialog_title">Subscribe to topic</string>


### PR DESCRIPTION
## Summary
- wrap the main activity in a DrawerLayout and add a right-hand reports drawer with loading, error, and empty states
- wire MainActivity to control the drawer, fetch quake reports, and render them via a dedicated adapter
- add reusable quake report parser/service/adapter classes plus supporting layouts, strings, and menu entry

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2e66bb54832dba97facd7efda7b9