### PR TITLE
Increase top padding on share screen

### DIFF
--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -7,7 +7,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal" android:paddingStart="15dp" android:paddingEnd="15dp" android:paddingTop="10dp" android:paddingBottom="10dp" android:id="@+id/share_root_view">
+            android:orientation="horizontal" android:paddingStart="15dp" android:paddingEnd="15dp" android:paddingTop="24dp" android:paddingBottom="10dp" android:id="@+id/share_root_view">
 
         <ProgressBar
                 style="?android:attr/progressBarStyle"


### PR DESCRIPTION
## Summary
- increase the top padding on the share screen root container for better spacing around the content

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc46394a5c832dbbee35c5b7712ee1