### PR TITLE
Improve quake reports layout and padding

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -483,10 +483,6 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
                 startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.main_menu_docs_url))))
                 true
             }
-            R.id.main_menu_reports -> {
-                bottomNavigation.selectedItemId = R.id.navigation_reports
-                true
-            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
@@ -1,5 +1,10 @@
 package io.heckel.ntfy.ui.reports
 
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.BulletSpan
+import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,6 +13,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.divider.MaterialDivider
 import io.heckel.ntfy.R
 
 class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHolder>(DiffCallback) {
@@ -24,20 +30,43 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = getItem(position)
         holder.title.text = item.headline
-        holder.subtitle.isVisible = !item.subline.isNullOrBlank()
-        holder.subtitle.text = item.subline
+        holder.subtitle.text = item.subline.orEmpty()
+        holder.subtitle.isVisible = holder.subtitle.text.isNotBlank()
+
         if (item.details.isEmpty()) {
             holder.details.isVisible = false
             holder.details.text = ""
+            holder.divider.isVisible = false
         } else {
-            holder.details.isVisible = true
-            holder.details.text = item.details.joinToString(separator = "\n") { (label, value) ->
-                if (label.isBlank()) {
-                    value
-                } else {
-                    "• $label: $value"
+            val gapWidth = holder.itemView.resources.getDimensionPixelSize(R.dimen.report_detail_bullet_gap)
+            val builder = SpannableStringBuilder()
+            item.details.forEach { (label, value) ->
+                if (label.isBlank() && value.isBlank()) {
+                    return@forEach
                 }
+                if (builder.isNotEmpty()) {
+                    builder.append('\n')
+                }
+                val lineStart = builder.length
+                if (label.isBlank()) {
+                    builder.append(value)
+                } else {
+                    val labelStart = builder.length
+                    builder.append(label)
+                    builder.setSpan(StyleSpan(Typeface.BOLD), labelStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    builder.append(": ")
+                    builder.append(value)
+                }
+                builder.setSpan(BulletSpan(gapWidth), lineStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
+
+            holder.details.isVisible = builder.isNotEmpty()
+            if (holder.details.isVisible) {
+                holder.details.text = builder
+            } else {
+                holder.details.text = ""
+            }
+            holder.divider.isVisible = holder.details.isVisible && holder.subtitle.isVisible
         }
     }
 
@@ -48,6 +77,7 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val title: TextView = view.findViewById(R.id.report_title)
         val subtitle: TextView = view.findViewById(R.id.report_subtitle)
+        val divider: MaterialDivider = view.findViewById(R.id.report_divider)
         val details: TextView = view.findViewById(R.id.report_details)
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -274,7 +274,7 @@
                 android:clickable="true"
                 android:clipToPadding="false"
                 android:focusable="true"
-                android:paddingTop="12dp"
+                android:paddingTop="@dimen/content_top_padding"
                 android:paddingBottom="5dp"
                 app:layoutManager="LinearLayoutManager" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
@@ -393,7 +393,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:clipToPadding="false"
-                android:paddingTop="4dp"
+                android:paddingTop="@dimen/content_top_padding"
                 android:paddingBottom="16dp"
                 android:scrollbars="vertical"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />

--- a/app/src/main/res/layout/item_quake_report.xml
+++ b/app/src/main/res/layout/item_quake_report.xml
@@ -6,8 +6,11 @@
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="12dp"
-    app:cardUseCompatPadding="true"
-    app:strokeWidth="0dp">
+    app:cardElevation="2dp"
+    app:cardUseCompatPadding="false"
+    app:shapeAppearance="?shapeAppearanceLargeComponent"
+    app:strokeColor="@color/gray_500"
+    app:strokeWidth="1dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -29,19 +32,32 @@
             android:id="@+id/report_subtitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="6dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:textColor="?attr/colorOnSurface"
+            android:alpha="0.8"
             android:visibility="gone" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/report_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="12dp"
+            android:visibility="gone"
+            app:dividerColor="@color/gray_500"
+            app:dividerInsetStart="0dp"
+            app:dividerInsetEnd="0dp" />
 
         <TextView
             android:id="@+id/report_details"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="12dp"
+            android:lineSpacingExtra="6dp"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="?attr/colorOnSurface"
-            android:lineSpacingExtra="4dp" />
+            android:textColor="?attr/colorOnSurface" />
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/menu_main_action_bar.xml
+++ b/app/src/main/res/menu/menu_main_action_bar.xml
@@ -6,10 +6,6 @@
     <item android:id="@+id/main_menu_notifications_disabled_forever" android:title="@string/detail_menu_notifications_disabled_forever"
           app:showAsAction="ifRoom" android:icon="@drawable/ic_notifications_off_white_outline_24dp"/>
     <item android:id="@+id/main_menu_settings" android:title="@string/main_menu_settings_title"/>
-    <item
-        android:id="@+id/main_menu_reports"
-        android:title="@string/main_menu_reports_title"
-        app:showAsAction="never" />
     <item android:id="@+id/main_menu_docs" android:title="@string/main_menu_docs_title"/>
     <item android:id="@+id/main_menu_rate" android:title="@string/main_menu_rate_title"/>
     <item android:id="@+id/main_menu_donate" android:title="@string/main_menu_donate_title"/>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="content_top_padding">24dp</dimen>
+    <dimen name="report_detail_bullet_gap">12dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- add a shared top padding dimension so the alerts and reports lists sit comfortably below the toolbar
- restyle quake report cards with dividers and formatted detail bullets to improve readability
- remove the redundant Laporan Gempa option from the overflow menu

## Testing
- ./gradlew lint *(fails: Android SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccaff554f0832d90643e6d62fc29d5