### PR TITLE
Improve quake reports presentation

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.divider.MaterialDivider
 import io.heckel.ntfy.R
+import java.util.Locale
 
 class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHolder>(DiffCallback) {
 
@@ -33,41 +34,98 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
         holder.subtitle.text = item.subline.orEmpty()
         holder.subtitle.isVisible = holder.subtitle.text.isNotBlank()
 
-        if (item.details.isEmpty()) {
-            holder.details.isVisible = false
-            holder.details.text = ""
-            holder.divider.isVisible = false
-        } else {
-            val gapWidth = holder.itemView.resources.getDimensionPixelSize(R.dimen.report_detail_bullet_gap)
-            val builder = SpannableStringBuilder()
-            item.details.forEach { (label, value) ->
-                if (label.isBlank() && value.isBlank()) {
-                    return@forEach
-                }
-                if (builder.isNotEmpty()) {
-                    builder.append('\n')
-                }
-                val lineStart = builder.length
-                if (label.isBlank()) {
-                    builder.append(value)
-                } else {
-                    val labelStart = builder.length
-                    builder.append(label)
-                    builder.setSpan(StyleSpan(Typeface.BOLD), labelStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    builder.append(": ")
-                    builder.append(value)
-                }
-                builder.setSpan(BulletSpan(gapWidth), lineStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
+        val context = holder.itemView.context
+        val defaultIntensityLabel = context.getString(R.string.report_intensity_default_label)
+        val defaultIdLabel = context.getString(R.string.report_id_default_label)
 
-            holder.details.isVisible = builder.isNotEmpty()
-            if (holder.details.isVisible) {
-                holder.details.text = builder
-            } else {
-                holder.details.text = ""
+        var intensityLabel: String? = null
+        var intensityValue: String? = null
+        var idLabel: String? = null
+        var idValue: String? = null
+        val remainingDetails = mutableListOf<Pair<String, String>>()
+
+        item.details.forEach { (rawLabel, rawValue) ->
+            val label = rawLabel.trim()
+            val value = rawValue.trim()
+            if (label.isBlank() && value.isBlank()) {
+                return@forEach
             }
-            holder.divider.isVisible = holder.details.isVisible && holder.subtitle.isVisible
+            if (value.isBlank()) {
+                return@forEach
+            }
+            val normalizedLabel = label.lowercase(Locale.getDefault())
+            when {
+                intensityValue == null && label.isNotBlank() && isIntensityLabel(normalizedLabel) -> {
+                    intensityLabel = label
+                    intensityValue = value
+                }
+                idValue == null && label.isNotBlank() && isIdLabel(normalizedLabel) -> {
+                    idLabel = label
+                    idValue = value
+                }
+                else -> {
+                    val displayValue = if (label.isNotBlank() && isDurationLabel(normalizedLabel) && needsDurationUnit(value)) {
+                        context.getString(R.string.report_duration_seconds, value)
+                    } else {
+                        value
+                    }
+                    remainingDetails.add(label to displayValue)
+                }
+            }
         }
+
+        val intensityText = intensityValue?.takeIf { it.isNotBlank() }
+        if (intensityText != null) {
+            val labelText = intensityLabel?.takeIf { it.isNotBlank() } ?: defaultIntensityLabel
+            holder.intensityLabel.text = labelText
+            holder.intensityValue.text = intensityText
+            holder.intensityContainer.isVisible = true
+        } else {
+            holder.intensityContainer.isVisible = false
+            holder.intensityLabel.text = ""
+            holder.intensityValue.text = ""
+        }
+
+        val gapWidth = holder.itemView.resources.getDimensionPixelSize(R.dimen.report_detail_bullet_gap)
+        val builder = SpannableStringBuilder()
+        remainingDetails.forEach { (label, value) ->
+            if (label.isBlank() && value.isBlank()) {
+                return@forEach
+            }
+            if (builder.isNotEmpty()) {
+                builder.append('\n')
+            }
+            val lineStart = builder.length
+            if (label.isBlank()) {
+                builder.append(value)
+            } else {
+                val labelStart = builder.length
+                builder.append(label)
+                builder.setSpan(StyleSpan(Typeface.BOLD), labelStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                builder.append(": ")
+                builder.append(value)
+            }
+            builder.setSpan(BulletSpan(gapWidth), lineStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        holder.details.isVisible = builder.isNotEmpty()
+        if (holder.details.isVisible) {
+            holder.details.text = builder
+        } else {
+            holder.details.text = ""
+        }
+
+        val idText = idValue?.takeIf { it.isNotBlank() }
+        if (idText != null) {
+            val labelText = idLabel?.takeIf { it.isNotBlank() } ?: defaultIdLabel
+            holder.reportId.text = context.getString(R.string.report_id_template, labelText, idText)
+            holder.reportId.isVisible = true
+        } else {
+            holder.reportId.text = ""
+            holder.reportId.isVisible = false
+        }
+
+        holder.divider.isVisible = holder.details.isVisible || holder.reportId.isVisible
     }
 
     override fun getItemId(position: Int): Long {
@@ -77,8 +135,12 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val title: TextView = view.findViewById(R.id.report_title)
         val subtitle: TextView = view.findViewById(R.id.report_subtitle)
+        val intensityContainer: View = view.findViewById(R.id.report_intensity_container)
+        val intensityLabel: TextView = view.findViewById(R.id.report_intensity_label)
+        val intensityValue: TextView = view.findViewById(R.id.report_intensity_value)
         val divider: MaterialDivider = view.findViewById(R.id.report_divider)
         val details: TextView = view.findViewById(R.id.report_details)
+        val reportId: TextView = view.findViewById(R.id.report_id)
     }
 
     private object DiffCallback : DiffUtil.ItemCallback<QuakeReport>() {
@@ -88,6 +150,46 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
 
         override fun areContentsTheSame(oldItem: QuakeReport, newItem: QuakeReport): Boolean {
             return oldItem == newItem
+        }
+    }
+
+    companion object {
+        private val INTENSITY_KEYWORDS = listOf("intens", "magnit", "skala")
+        private val DURATION_KEYWORDS = listOf("durasi", "duration", "lama")
+        private val DURATION_NUMBER_REGEX = Regex("^[0-9]+([.,][0-9]+)?$")
+
+        private fun isIntensityLabel(label: String): Boolean {
+            return INTENSITY_KEYWORDS.any { keyword -> label.contains(keyword) }
+        }
+
+        private fun isDurationLabel(label: String): Boolean {
+            return DURATION_KEYWORDS.any { keyword -> label.contains(keyword) }
+        }
+
+        private fun isIdLabel(label: String): Boolean {
+            if (label == "id") {
+                return true
+            }
+            if (label.startsWith("id ")) {
+                return true
+            }
+            if (label.endsWith(" id")) {
+                return true
+            }
+            if (label.contains("laporan") && label.contains("id")) {
+                return true
+            }
+            if (label.contains("event") && label.contains("id")) {
+                return true
+            }
+            if (label.contains("gempa") && label.contains("id")) {
+                return true
+            }
+            return false
+        }
+
+        private fun needsDurationUnit(value: String): Boolean {
+            return DURATION_NUMBER_REGEX.matches(value.trim())
         }
     }
 }

--- a/app/src/main/res/drawable/bg_report_intensity.xml
+++ b/app/src/main/res/drawable/bg_report_intensity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="?attr/colorPrimary" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -337,7 +337,7 @@
         android:gravity="top"
         android:orientation="vertical"
         android:paddingStart="16dp"
-        android:paddingTop="16dp"
+        android:paddingTop="@dimen/content_top_padding"
         android:paddingEnd="16dp"
         android:paddingBottom="24dp"
         android:visibility="gone"
@@ -393,7 +393,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:clipToPadding="false"
-                android:paddingTop="@dimen/content_top_padding"
                 android:paddingBottom="16dp"
                 android:scrollbars="vertical"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />

--- a/app/src/main/res/layout/item_quake_report.xml
+++ b/app/src/main/res/layout/item_quake_report.xml
@@ -22,21 +22,53 @@
             android:id="@+id/report_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:maxLines="2"
+            android:ellipsize="end"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
             android:textColor="?attr/colorOnSurface"
-            android:textStyle="bold"
-            android:maxLines="2"
-            android:ellipsize="end" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/report_subtitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="6dp"
+            android:alpha="0.8"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:textColor="?attr/colorOnSurface"
-            android:alpha="0.8"
             android:visibility="gone" />
+
+        <LinearLayout
+            android:id="@+id/report_intensity_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_report_intensity"
+            android:orientation="vertical"
+            android:paddingStart="12dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="8dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/report_intensity_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0.8"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                android:textAllCaps="true"
+                android:textColor="?attr/colorOnPrimary" />
+
+            <TextView
+                android:id="@+id/report_intensity_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                android:textColor="?attr/colorOnPrimary"
+                android:textStyle="bold" />
+        </LinearLayout>
 
         <com.google.android.material.divider.MaterialDivider
             android:id="@+id/report_divider"
@@ -45,8 +77,8 @@
             android:layout_marginTop="12dp"
             android:visibility="gone"
             app:dividerColor="@color/gray_500"
-            app:dividerInsetStart="0dp"
-            app:dividerInsetEnd="0dp" />
+            app:dividerInsetEnd="0dp"
+            app:dividerInsetStart="0dp" />
 
         <TextView
             android:id="@+id/report_details"
@@ -54,10 +86,19 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:lineSpacingExtra="6dp"
-            android:paddingStart="4dp"
-            android:paddingEnd="4dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:textColor="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/report_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:alpha="0.7"
+            android:gravity="end"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+            android:textColor="?attr/colorOnSurface"
+            android:visibility="gone" />
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,10 @@
     <string name="reports_error_text">Unable to load quake reports. Pull to refresh or tap to retry.</string>
     <string name="reports_error_with_reason">Unable to load quake reports. Pull to refresh or tap to retry.
 %1$s</string>
+    <string name="report_intensity_default_label">Intensitas</string>
+    <string name="report_id_default_label">ID</string>
+    <string name="report_id_template">%1$s: %2$s</string>
+    <string name="report_duration_seconds">%1$s detik</string>
 
     <!-- Add dialog -->
     <string name="add_dialog_title">Subscribe to topic</string>


### PR DESCRIPTION
## Summary
- adjust the reports list container padding so the content aligns with the rest of the app
- refresh the quake report card layout to highlight intensity information, add an ID footer, and clean up spacing
- update the adapter to surface intensity and ID separately, append a unit to durations, and support the new layout

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cccc6cbc38832d87d10630b3d81052