### PR TITLE
Revamp quake reports layout and styling

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/reports/QuakeReportsAdapter.kt
@@ -118,14 +118,16 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
         val idText = idValue?.takeIf { it.isNotBlank() }
         if (idText != null) {
             val labelText = idLabel?.takeIf { it.isNotBlank() } ?: defaultIdLabel
-            holder.reportId.text = context.getString(R.string.report_id_template, labelText, idText)
-            holder.reportId.isVisible = true
+            holder.reportIdLabel.text = labelText
+            holder.reportIdValue.text = idText
+            holder.reportIdContainer.isVisible = true
         } else {
-            holder.reportId.text = ""
-            holder.reportId.isVisible = false
+            holder.reportIdLabel.text = ""
+            holder.reportIdValue.text = ""
+            holder.reportIdContainer.isVisible = false
         }
 
-        holder.divider.isVisible = holder.details.isVisible || holder.reportId.isVisible
+        holder.divider.isVisible = holder.details.isVisible
     }
 
     override fun getItemId(position: Int): Long {
@@ -140,7 +142,9 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
         val intensityValue: TextView = view.findViewById(R.id.report_intensity_value)
         val divider: MaterialDivider = view.findViewById(R.id.report_divider)
         val details: TextView = view.findViewById(R.id.report_details)
-        val reportId: TextView = view.findViewById(R.id.report_id)
+        val reportIdContainer: View = view.findViewById(R.id.report_id_container)
+        val reportIdLabel: TextView = view.findViewById(R.id.report_id_label)
+        val reportIdValue: TextView = view.findViewById(R.id.report_id_value)
     }
 
     private object DiffCallback : DiffUtil.ItemCallback<QuakeReport>() {
@@ -156,7 +160,6 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
     companion object {
         private val INTENSITY_KEYWORDS = listOf("intens", "magnit", "skala")
         private val DURATION_KEYWORDS = listOf("durasi", "duration", "lama")
-        private val DURATION_NUMBER_REGEX = Regex("^[0-9]+([.,][0-9]+)?$")
 
         private fun isIntensityLabel(label: String): Boolean {
             return INTENSITY_KEYWORDS.any { keyword -> label.contains(keyword) }
@@ -189,7 +192,14 @@ class QuakeReportsAdapter : ListAdapter<QuakeReport, QuakeReportsAdapter.ViewHol
         }
 
         private fun needsDurationUnit(value: String): Boolean {
-            return DURATION_NUMBER_REGEX.matches(value.trim())
+            val trimmed = value.trim()
+            if (trimmed.isEmpty()) {
+                return false
+            }
+            if (trimmed.any { it.isLetter() }) {
+                return false
+            }
+            return true
         }
     }
 }

--- a/app/src/main/res/drawable/bg_report_id.xml
+++ b/app/src/main/res/drawable/bg_report_id.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="12dp" />
+    <solid android:color="@color/report_id_background" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -386,6 +386,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
+            android:background="?attr/colorSurface"
             android:visibility="gone">
 
             <androidx.recyclerview.widget.RecyclerView
@@ -393,6 +394,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:clipToPadding="false"
+                android:paddingTop="@dimen/content_top_padding"
                 android:paddingBottom="16dp"
                 android:scrollbars="vertical"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />

--- a/app/src/main/res/layout/item_quake_report.xml
+++ b/app/src/main/res/layout/item_quake_report.xml
@@ -18,63 +18,125 @@
         android:orientation="vertical"
         android:padding="16dp">
 
-        <TextView
-            android:id="@+id/report_title"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:maxLines="2"
-            android:ellipsize="end"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-            android:textColor="?attr/colorOnSurface"
-            android:textStyle="bold" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/report_subtitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:alpha="0.8"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="?attr/colorOnSurface"
-            android:visibility="gone" />
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/report_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/report_subtitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:alpha="0.8"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+                    android:textColor="?attr/colorOnSurface"
+                    android:visibility="gone" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/report_id_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:background="@drawable/bg_report_id"
+                android:orientation="vertical"
+                android:paddingStart="10dp"
+                android:paddingTop="6dp"
+                android:paddingEnd="10dp"
+                android:paddingBottom="6dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/report_id_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:alpha="0.8"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                    android:textAllCaps="true"
+                    android:textColor="?attr/colorOnSurface" />
+
+                <TextView
+                    android:id="@+id/report_id_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/report_intensity_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
+            android:layout_marginTop="16dp"
             android:background="@drawable/bg_report_intensity"
-            android:orientation="vertical"
-            android:paddingStart="12dp"
-            android:paddingTop="8dp"
-            android:paddingEnd="12dp"
-            android:paddingBottom="8dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="14dp"
+            android:paddingTop="10dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="10dp"
             android:visibility="gone">
 
-            <TextView
-                android:id="@+id/report_intensity_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:alpha="0.8"
-                android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
-                android:textAllCaps="true"
-                android:textColor="?attr/colorOnPrimary" />
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:contentDescription="@null"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_bolt_white_24dp"
+                android:tint="?attr/colorOnPrimary" />
 
-            <TextView
-                android:id="@+id/report_intensity_value"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                android:textColor="?attr/colorOnPrimary"
-                android:textStyle="bold" />
+                android:layout_marginStart="10dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/report_intensity_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:alpha="0.8"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                    android:textAllCaps="true"
+                    android:textColor="?attr/colorOnPrimary" />
+
+                <TextView
+                    android:id="@+id/report_intensity_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                    android:textColor="?attr/colorOnPrimary"
+                    android:textStyle="bold" />
+            </LinearLayout>
         </LinearLayout>
 
         <com.google.android.material.divider.MaterialDivider
             android:id="@+id/report_divider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginTop="12dp"
+            android:layout_marginTop="16dp"
             android:visibility="gone"
             app:dividerColor="@color/gray_500"
             app:dividerInsetEnd="0dp"
@@ -84,21 +146,10 @@
             android:id="@+id/report_details"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
+            android:layout_marginTop="16dp"
             android:lineSpacingExtra="6dp"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
             android:textColor="?attr/colorOnSurface" />
-
-        <TextView
-            android:id="@+id/report_id"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:alpha="0.7"
-            android:gravity="end"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
-            android:textColor="?attr/colorOnSurface"
-            android:visibility="gone" />
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="report_id_background">#1F3A35</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,5 +13,7 @@
     <color name="teal_dark">#2a6e60</color> <!-- Action bar background in action mode (light mode) -->
     <color name="red_light">#fe4d2e</color> <!-- Danger text (dark mode) -->
     <color name="red_dark">#c30000</color> <!-- Danger text (light mode) -->
+
+    <color name="report_id_background">#E0F2F1</color>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,7 +99,6 @@
 %1$s</string>
     <string name="report_intensity_default_label">Intensitas</string>
     <string name="report_id_default_label">ID</string>
-    <string name="report_id_template">%1$s: %2$s</string>
     <string name="report_duration_seconds">%1$s detik</string>
 
     <!-- Add dialog -->


### PR DESCRIPTION
## Summary
- add background and top padding to the reports list container so the page spacing matches the rest of the app
- redesign quake report cards with an ID chip, highlighted intensity section, and refreshed spacing for the supporting details
- add supporting resources and logic tweaks so duration values always show units while respecting light and dark themes

## Testing
- `./gradlew lint` *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd44476fc832da32bd3504c9e6424