### PR TITLE
Fix bottom navigation indicator dimensions

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -406,6 +406,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="?attr/colorSurface"
+        android:clipToPadding="true"
         app:itemActiveIndicatorStyle="@style/Widget.QuakeAlert.BottomNavigation.ActiveIndicator"
         app:itemHorizontalTranslationEnabled="false"
         app:itemIconTint="@color/main_bottom_nav_item_tint"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,8 +33,6 @@
     </style>
 
     <style name="Widget.QuakeAlert.BottomNavigation.ActiveIndicator" parent="">
-        <item name="android:width">wrap_content</item>
-        <item name="android:height">wrap_content</item>
         <item name="android:paddingStart">16dp</item>
         <item name="android:paddingEnd">16dp</item>
         <item name="android:paddingTop">8dp</item>


### PR DESCRIPTION
## Summary
- remove the invalid wrap_content values from the bottom navigation active indicator style
- ensure the bottom navigation view clips to its padding

## Testing
- ./gradlew assembleDebug *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd308329ac832d9299265e96ec3e5c