### PR TITLE
Adjust actions section padding in detail layout

### DIFF
--- a/app/src/main/res/layout/fragment_detail_item.xml
+++ b/app/src/main/res/layout/fragment_detail_item.xml
@@ -139,9 +139,11 @@
                 android:id="@+id/detail_item_actions_wrapper"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginEnd="4dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="6dp"
                 android:visibility="gone"
-                android:padding="0dp" android:layout_marginStart="4dp" android:layout_marginTop="4dp">
+                android:padding="0dp"
+                android:layout_marginTop="4dp">
 
             <com.google.android.material.button.MaterialButton
                     android:text="Bing it"


### PR DESCRIPTION
## Summary
- align the actions wrapper in the detail item card with the surrounding content by updating its horizontal margins

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd44ab4c80832dbab01d8ac98d303a